### PR TITLE
Fix: alpha version

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,6 @@ import UnirepSocial from "@unirep/unirep-social/artifacts/contracts/UnirepSocial
 
 // const SERVER = 'http://localhost:3001/'
 const DEFAULT_ETH_PROVIDER_URL = 'ws://localhost:8545'
-const SERVER = 'https://unirep.social/'
 // const SERVER = 'http://3.20.204.166'
 // const DEFAULT_ETH_PROVIDER_URL = 'wss://eth-goerli.alchemyapi.io/v2/tYp-IJU_idg28iohx9gsLqhq6KRZxk7f'
 const DEFAULT_ETH_PROVIDER = DEFAULT_ETH_PROVIDER_URL.startsWith('http') ?
@@ -45,7 +44,6 @@ const ABOUT_URL = "https://about.unirep.social";
 const LOAD_POST_COUNT = 10
 
 export {
-    SERVER,
     DEFAULT_ETH_PROVIDER,
     DEFAULT_START_BLOCK,
     DEFAULT_MAX_EPOCH_KEY_NONCE,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -280,7 +280,7 @@ const genProof = async (identity: string, epkNonce: number = 0, proveKarmaAmount
 
 const makeURL = (action: string, data: any = {}) => {
     const params = new URLSearchParams(data)
-    return `${config.SERVER}api/${action}?${params}`
+    return `/api/${action}?${params}`
 }
 
 const header = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,16 @@ const webpack = require('webpack')
 module.exports = {
   entry: ['./src/index.tsx'],
   mode: 'development',
+  devServer: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        router: () => 'http://localhost:3001'
+      }
+    },
+    historyApiFallback: true
+  },
   output: {
     path: path.resolve(__dirname, 'build'),
     publicPath: '/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,28 +1028,15 @@
     "@unirep/unirep" "git+https://github.com/Unirep/unirep.git"
     argparse "^2.0.1"
     base64url "^3.0.1"
-    ethers "^5.4.6"
+    dotenv "^10.0.0"
+    ethers "^5.5.4"
     mongoose "^5.12.10"
     typescript "^4.0.5"
 
-"@unirep/unirep@git+https://github.com/Unirep/unirep.git":
+"@unirep/unirep@git+https://github.com/Unirep/unirep.git", "@unirep/unirep@git+https://github.com/Unirep/unirep.git#alpha":
   version "1.0.0"
   resolved "git+https://github.com/Unirep/unirep.git#60d7bad732b2b0580e6357b4cb290534dcb43297"
   dependencies:
-    argparse "^2.0.1"
-    base64url "^3.0.1"
-    ethers "^5.4.6"
-    typescript "^4.5.4"
-
-"@unirep/unirep@git+https://github.com/Unirep/unirep.git#alpha":
-  version "1.0.0"
-  resolved "git+https://github.com/Unirep/unirep.git#60d7bad732b2b0580e6357b4cb290534dcb43297"
-  dependencies:
-    "@typechain/ethers-v5" "^9.0.0"
-    "@typechain/hardhat" "^4.0.0"
-    "@unirep/circuits" "git+https://github.com/Unirep/circuits.git"
-    "@unirep/contracts" "git+https://github.com/Unirep/contracts.git"
-    "@unirep/crypto" "git+https://github.com/Unirep/crypto.git"
     argparse "^2.0.1"
     base64url "^3.0.1"
     ethers "^5.4.6"
@@ -1577,9 +1564,9 @@ blake2b-wasm@^2.4.0:
     b4a "^1.0.1"
     nanoassert "^2.0.0"
 
-"blake2b-wasm@git+https://github.com/jbaylina/blake2b-wasm.git":
+"blake2b-wasm@https://github.com/jbaylina/blake2b-wasm.git":
   version "2.1.0"
-  resolved "git+https://github.com/jbaylina/blake2b-wasm.git#0d5f024b212429c7f50a7f533aa3a2406b5b42b3"
+  resolved "https://github.com/jbaylina/blake2b-wasm.git#0d5f024b212429c7f50a7f533aa3a2406b5b42b3"
   dependencies:
     nanoassert "^1.0.0"
 


### PR DESCRIPTION
- Use the same version as unirep-social
- Get Unirep contract by
```
const unirepContract = getUnirepContract(
    config.UNIREP,
    config.DEFAULT_ETH_PROVIDER
);
```
- Fix `commentsCount` by using the queried `comments` instead of `data.comments`