### PR TITLE
fix post block in post page still redirect bug

### DIFF
--- a/src/components/postBlock/postBlock.tsx
+++ b/src/components/postBlock/postBlock.tsx
@@ -66,6 +66,11 @@ const PostBlock = ({ postId, page }: Props) => {
         postContext.loadCommentsByPostId(postId)
     }, [])
 
+    const gotoPostPage = () => {
+        if (page === Page.Post) return
+        history.push(`/post/${post.id}`, { commentId: '' })
+    }
+
     return (
         <div className="post-block">
             <div className="block-header">
@@ -105,12 +110,7 @@ const PostBlock = ({ postId, page }: Props) => {
                 </a>
             </div>
             {page === Page.Home ? <div className="divider"></div> : <div></div>}
-            <div
-                className="block-content"
-                onClick={() =>
-                    history.push(`/post/${post.id}`, { commentId: '' })
-                }
-            >
+            <div className="block-content" onClick={gotoPostPage}>
                 <div className="title">{post.title}</div>
                 <div className="content">
                     <div


### PR DESCRIPTION
block the post block from redirecting pages if the current page url is `/post/`